### PR TITLE
인증 로직 개선 및 오류 처리 코드 정리

### DIFF
--- a/src/main/java/com/stockleague/backend/auth/oauth/client/KakaoOAuthClient.java
+++ b/src/main/java/com/stockleague/backend/auth/oauth/client/KakaoOAuthClient.java
@@ -42,10 +42,10 @@ public class KakaoOAuthClient implements OAuthClient {
     }
 
     @Override
-    public OAuthUserInfo requestUserInfo(OAuthLoginRequestDto requestDto){
+    public OAuthUserInfo requestUserInfo(OAuthLoginRequestDto requestDto) {
         log.info("[Kakao] 인가 코드로 토큰 요청");
 
-        try{
+        try {
             // Access Token 요청
             Map<String, Object> tokenResponse = kakaoAuthWebClient.post()
                     .uri(kakaoProperties.getTokenUri())
@@ -56,7 +56,8 @@ public class KakaoOAuthClient implements OAuthClient {
                             "&redirect_uri=" + kakaoProperties.getRedirectUri() +
                             "&code=" + requestDto.getAuthCode())
                     .retrieve()
-                    .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                    .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                    })
                     .block();
 
             if (tokenResponse == null || !tokenResponse.containsKey("access_token")) {
@@ -69,13 +70,14 @@ public class KakaoOAuthClient implements OAuthClient {
                     .uri(kakaoProperties.getUserInfoUri())
                     .headers(headers -> headers.setBearerAuth(accessToken))
                     .retrieve()
-                    .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                    .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                    })
                     .block();
 
             log.info("[Kakao] 사용자 정보 조회 완료");
 
             return new KaKaoUserInfo(userAttributes);
-        }catch (WebClientResponseException e) {
+        } catch (WebClientResponseException e) {
             log.warn("[KakaoOAuthClient] WebClientResponseException: status={}, body={}",
                     e.getStatusCode(), e.getResponseBodyAsString());
             if (e.getStatusCode().is4xxClientError()) {
@@ -92,7 +94,6 @@ public class KakaoOAuthClient implements OAuthClient {
             log.error("[KakaoOAuthClient] 예기치 못한 오류 발생", e);
             throw new GlobalException(GlobalErrorCode.OAUTH_SERVER_ERROR);
         }
-
 
 
     }

--- a/src/main/java/com/stockleague/backend/auth/oauth/info/KaKaoUserInfo.java
+++ b/src/main/java/com/stockleague/backend/auth/oauth/info/KaKaoUserInfo.java
@@ -24,13 +24,6 @@ public class KaKaoUserInfo implements OAuthUserInfo {
     }
 
     @Override
-    public Integer getBirthYear() {
-        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
-        String year = (String) account.get("birthyear"); // "1996"
-        return year != null ? Integer.parseInt(year) : null;
-    }
-
-    @Override
     public OauthServerType getProvider() {
         return OauthServerType.KAKAO;
     }

--- a/src/main/java/com/stockleague/backend/auth/oauth/info/OAuthUserInfo.java
+++ b/src/main/java/com/stockleague/backend/auth/oauth/info/OAuthUserInfo.java
@@ -5,6 +5,5 @@ import com.stockleague.backend.user.domain.OauthServerType;
 public interface OAuthUserInfo {
     String getOauthId();
     String getNickname();
-    Integer getBirthYear();
     OauthServerType getProvider();
 }

--- a/src/main/java/com/stockleague/backend/auth/service/AuthService.java
+++ b/src/main/java/com/stockleague/backend/auth/service/AuthService.java
@@ -76,7 +76,7 @@ public class AuthService {
 
     public OAuthLogoutResponseDto logout(String accessToken, String refreshToken) {
         if(!jwtProvider.validateToken(accessToken)) {
-            throw new GlobalException(GlobalErrorCode.INVALID_REFRESH_TOKEN);
+            throw new GlobalException(GlobalErrorCode.INVALID_ACCESS_TOKEN);
         }
 
         Long userId = jwtProvider.getUserId(accessToken);

--- a/src/main/java/com/stockleague/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/stockleague/backend/global/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
                                 "/api/v1/auth/**",
                                 "/error"
                         ).permitAll()
-                        .requestMatchers("/admin/**").hasRole("ADMIN") // 관리자 전용 URL
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN") // 관리자 전용 URL
                         .anyRequest().authenticated() // 나머지는 로그인한 사용자만 접근 가능
                 )
                 .addFilterBefore(jwtLoggingFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/stockleague/backend/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/stockleague/backend/global/exception/GlobalErrorCode.java
@@ -13,14 +13,16 @@ public enum GlobalErrorCode {
     OAUTH_AUTH_FAILED(HttpStatus.BAD_REQUEST, "소셜 로그인 인증에 실패했습니다."),
     OAUTH_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인 서버와 통신 중 문제가 발생했습니다."),
     AGE_RESTRICTION(HttpStatus.BAD_REQUEST, "15세 미만은 가입할 수 없습니다."),
-    INVALID_TEMP_TOKEN(HttpStatus.UNAUTHORIZED, "임시 토큰이 유효하지 않습니다."),
     ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 가입된 유저입니다."),
 
     // 닉네임 형식
     NICKNAME_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "닉네임 형식이 올바르지 않습니다."),
     DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
 
-    // 리프레시 토큰
+    // 토큰
+    INVALID_TEMP_TOKEN(HttpStatus.UNAUTHORIZED, "임시 토큰이 유효하지 않습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "엑세스 토큰이 유효하지 않습니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 만료되었습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 유효하지 않습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
 


### PR DESCRIPTION
1. 카카오 OAuth 응답에서 생년 정보 제거
2. SecurityConfig의 admin 경로 패턴 수정
3. 엑세스 토큰 관련 에러 코드 추가